### PR TITLE
Update telerising.update to speed up download

### DIFF
--- a/root/telerising.update
+++ b/root/telerising.update
@@ -5,7 +5,7 @@ echo "Updating the NEW Telerising-API"
 PWD=$(pwd)
 
 rm -rf /telerising/telerising
-git clone https://github.com/sunsettrack4/telerising-api /telerising/telerising
+git clone -b main --single-branch https://github.com/sunsettrack4/telerising-api /telerising/telerising --depth 1
 
 cd /telerising/telerising
 git checkout main


### PR DESCRIPTION
The existing git clone command downloaded all commits in the repository, which is quite a lot of data since each commit is ~50MB blobs of binary data.

This change should speed it up by only getting the latest version of the files without the git history.