### PR TITLE
Update telerising.update

### DIFF
--- a/root/telerising.update
+++ b/root/telerising.update
@@ -5,7 +5,7 @@ echo "Updating the NEW Telerising-API"
 PWD=$(pwd)
 
 rm -rf /telerising/telerising
-git clone https://github.com/sunsettrack4/telerising-api /telerising/telerising
+git clone https://github.com/sunsettrack4/telerising-api /telerising/telerising --depth 1
 
 cd /telerising/telerising
 git checkout main


### PR DESCRIPTION
The --depth 1 parameter in git clone creates a shallow clone of a git repository by limiting the history to the latest commit and thus downloading only the most recent data, saving time and disk space.
Or is there a special reason why you decided against "--depth 1"?